### PR TITLE
Use phpmyadmin:5.2-apache directly; include in offline bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This is also an operational log of our REDcap deployment and management.
 * changes to infrastructure (e.g. switching to a new service VM, changing what service user we run the service from, etc.)
 * important changes to scripts that manage data within REDcap
 
+## 2026-03-10
+
+- Mirror the upstream `phpmyadmin:5.2-apache` image to GHCR via `scripts/build_images.sh` instead of relying on a separate local Dockerfile build.
+- Update contribution instructions to reflect the phpMyAdmin GHCR mirror workflow.
+
 ## 2026-03-06
 
 - Introduce explicit GHCR image versioning for the REDCap stack.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ This is also an operational log of our REDcap deployment and management.
 * changes to infrastructure (e.g. switching to a new service VM, changing what service user we run the service from, etc.)
 * important changes to scripts that manage data within REDcap
 
-## 2026-03-10
+## 2026-03-11
 
-- Mirror the upstream `phpmyadmin:5.2-apache` image to GHCR via `scripts/build_images.sh` instead of relying on a separate local Dockerfile build.
-- Update contribution instructions to reflect the phpMyAdmin GHCR mirror workflow.
+- Revert `docker-compose.yml` to use the upstream `phpmyadmin:5.2-apache` image directly instead of a GHCR mirror.
+- Include `phpmyadmin:5.2-apache` in the offline bundle documentation in `INSTALL.md` so TSD deployments do not require Docker Hub access at runtime.
+- Update `CONTRIBUTING.md` to clarify that phpMyAdmin is not published to GHCR.
 
 ## 2026-03-06
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,6 @@ bash scripts/build_images.sh --push
 
 If you publish a new tag, update `IMAGE_TAG` in `.env` to match.
 
-phpMyAdmin is mirrored from the upstream `phpmyadmin:5.2-apache` image to `ghcr.io/norment/redcap-phpmyadmin:${IMAGE_TAG}` by `scripts/build_images.sh`.
+phpMyAdmin uses the upstream `phpmyadmin:5.2-apache` image directly and is not published to GHCR. It is included in the offline bundle pulled from Docker Hub — see [INSTALL.md](INSTALL.md).
 
 Note: `podman load` on TSD preserves the image name/tag stored in the tar. Ensure the offline bundle is created from the GHCR-tagged images (e.g., `ghcr.io/norment/redcap-webserver:${IMAGE_TAG}`), otherwise TSD users will need to retag after loading.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,6 @@ bash scripts/build_images.sh --push
 
 If you publish a new tag, update `IMAGE_TAG` in `.env` to match.
 
-phpMyAdmin uses the upstream `phpmyadmin:5.2-apache` image and is not published to GHCR.
+phpMyAdmin is mirrored from the upstream `phpmyadmin:5.2-apache` image to `ghcr.io/norment/redcap-phpmyadmin:${IMAGE_TAG}` by `scripts/build_images.sh`.
 
 Note: `podman load` on TSD preserves the image name/tag stored in the tar. Ensure the offline bundle is created from the GHCR-tagged images (e.g., `ghcr.io/norment/redcap-webserver:${IMAGE_TAG}`), otherwise TSD users will need to retag after loading.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,37 +36,40 @@ To deploy REDCap, you need its source code requiring a valid end-user license [a
 ## Import Files to TSD
 TSD has no internet access. Prepare the container images on a machine with internet access using `docker`, then import the resulting `.zip` bundle to TSD.
 
-On macOS (or any non-amd64 host), set `DOCKER_DEFAULT_PLATFORM=linux/amd64` so the bundle matches TSD's runtime architecture. Pull all images from GHCR and create a single offline bundle:
+On macOS (or any non-amd64 host), set `DOCKER_DEFAULT_PLATFORM=linux/amd64` so the bundle matches TSD's runtime architecture. Pull the GHCR images and the upstream phpMyAdmin image, then create a single offline bundle:
 
 ```bash
 export IMAGE_TAG=2.0.0  # set this to the tag you want to deploy
 export DOCKER_DEFAULT_PLATFORM=linux/amd64
 
+# Pull GHCR images
 docker pull ghcr.io/norment/redcap-webserver:${IMAGE_TAG}
-docker pull ghcr.io/norment/redcap-phpmyadmin:${IMAGE_TAG}
 docker pull ghcr.io/norment/redcap-mysql:${IMAGE_TAG}
 docker pull ghcr.io/norment/redcap-cron:${IMAGE_TAG}
 
+# Pull phpMyAdmin directly from Docker Hub
+docker pull phpmyadmin:5.2-apache
+
 # Verify all images are amd64 before saving
 docker image inspect --platform linux/amd64 ghcr.io/norment/redcap-webserver:${IMAGE_TAG} --format '{{.Os}}/{{.Architecture}}'
-docker image inspect --platform linux/amd64 ghcr.io/norment/redcap-phpmyadmin:${IMAGE_TAG} --format '{{.Os}}/{{.Architecture}}'
 docker image inspect --platform linux/amd64 ghcr.io/norment/redcap-mysql:${IMAGE_TAG} --format '{{.Os}}/{{.Architecture}}'
 docker image inspect --platform linux/amd64 ghcr.io/norment/redcap-cron:${IMAGE_TAG} --format '{{.Os}}/{{.Architecture}}'
+docker image inspect --platform linux/amd64 phpmyadmin:5.2-apache --format '{{.Os}}/{{.Architecture}}'
 
 # All four should print "linux/amd64" - if not, see troubleshooting note below
 
 docker save --platform linux/amd64 \
   ghcr.io/norment/redcap-webserver:${IMAGE_TAG} \
-  ghcr.io/norment/redcap-phpmyadmin:${IMAGE_TAG} \
   ghcr.io/norment/redcap-mysql:${IMAGE_TAG} \
   ghcr.io/norment/redcap-cron:${IMAGE_TAG} \
+  phpmyadmin:5.2-apache \
   -o redcap-images-${IMAGE_TAG}.tar
 
 zip redcap-images-${IMAGE_TAG}.zip redcap-images-${IMAGE_TAG}.tar
 rm redcap-images-${IMAGE_TAG}.tar  # Clean up: keep only the zip for transfer
 ```
 
-**Troubleshooting for Apple Silicon Macs:** If verification shows `linux/arm64` despite setting `DOCKER_DEFAULT_PLATFORM`, remove all local redcap images (`docker rmi -f $(docker images 'ghcr.io/norment/redcap-*' -q)`) and try the pull commands again. If `docker save` fails, make sure you use `docker save --platform linux/amd64` as above. If plain `docker image inspect` prints `/` for Os/Architecture, that means the tag resolves to a multi-arch manifest list; verify with `docker image inspect --platform linux/amd64 ...` instead.
+**Troubleshooting for Apple Silicon Macs:** If verification shows `linux/arm64` despite setting `DOCKER_DEFAULT_PLATFORM`, remove all local redcap images (`docker rmi -f $(docker images 'ghcr.io/norment/redcap-*' -q) && docker rmi -f phpmyadmin:5.2-apache`) and try the pull commands again. If `docker save` fails, make sure you use `docker save --platform linux/amd64` as above. If plain `docker image inspect` prints `/` for Os/Architecture, that means the tag resolves to a multi-arch manifest list; verify with `docker image inspect --platform linux/amd64 ...` instead.
 
 If the GHCR packages are private, authenticate before pulling:
 ```bash
@@ -105,7 +108,7 @@ podman load -i redcap-images-${IMAGE_TAG}.tar
 Optional check after loading on TSD:
 ```bash
 podman image inspect ghcr.io/norment/redcap-webserver:${IMAGE_TAG} --format '{{.Os}}/{{.Architecture}}'
-podman image inspect ghcr.io/norment/redcap-phpmyadmin:${IMAGE_TAG} --format '{{.Os}}/{{.Architecture}}'
+podman image inspect phpmyadmin:5.2-apache --format '{{.Os}}/{{.Architecture}}'
 ```
 Expected output: `linux/amd64`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     phpmyadmin:
         depends_on:
             - database
-        image: ghcr.io/norment/redcap-phpmyadmin:${IMAGE_TAG}
+        image: phpmyadmin:5.2-apache
         restart: always
         container_name: ${PREFIX}phpmyadmin
         env_file: .env

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -12,6 +12,7 @@ Defaults:
 Notes:
   - Without --push, builds a single-platform image and loads it into the local Docker engine.
   - With --push, builds a multi-arch manifest for linux/amd64 and linux/arm64 and pushes to GHCR.
+  - phpMyAdmin is mirrored from the upstream phpmyadmin:5.2-apache image.
 USAGE
 }
 
@@ -80,6 +81,20 @@ build_one() {
   fi
 }
 
+mirror_one() {
+  local name="$1"
+  local source_image="$2"
+  local target_image="ghcr.io/norment/redcap-${name}:${IMAGE_TAG}"
+
+  if [[ "${PUSH}" -eq 1 ]]; then
+    docker buildx imagetools create --tag "${target_image}" "${source_image}"
+  else
+    docker pull --platform "${PLATFORM}" "${source_image}"
+    docker tag "${source_image}" "${target_image}"
+  fi
+}
+
 build_one webserver webserver
+mirror_one phpmyadmin phpmyadmin:5.2-apache
 build_one mysql mysql
 build_one cron cron

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -12,7 +12,7 @@ Defaults:
 Notes:
   - Without --push, builds a single-platform image and loads it into the local Docker engine.
   - With --push, builds a multi-arch manifest for linux/amd64 and linux/arm64 and pushes to GHCR.
-  - phpMyAdmin is mirrored from the upstream phpmyadmin:5.2-apache image.
+  - phpMyAdmin uses the upstream phpmyadmin:5.2-apache image and is not built here.
 USAGE
 }
 
@@ -81,20 +81,6 @@ build_one() {
   fi
 }
 
-mirror_one() {
-  local name="$1"
-  local source_image="$2"
-  local target_image="ghcr.io/norment/redcap-${name}:${IMAGE_TAG}"
-
-  if [[ "${PUSH}" -eq 1 ]]; then
-    docker buildx imagetools create --tag "${target_image}" "${source_image}"
-  else
-    docker pull --platform "${PLATFORM}" "${source_image}"
-    docker tag "${source_image}" "${target_image}"
-  fi
-}
-
 build_one webserver webserver
-mirror_one phpmyadmin phpmyadmin:5.2-apache
 build_one mysql mysql
 build_one cron cron


### PR DESCRIPTION
## Summary

Resolves #23.

phpMyAdmin is pulled directly from Docker Hub (`phpmyadmin:5.2-apache`) and does **not** need to be built or mirrored to GHCR. For offline TSD deployments (which have no internet access at runtime), it is instead included in the offline bundle at preparation time alongside the GHCR images.

## Changes

- **`docker-compose.yml`**: reverts phpMyAdmin image to `phpmyadmin:5.2-apache` (upstream, not GHCR)
- **`INSTALL.md`**: documents pulling `phpmyadmin:5.2-apache` from Docker Hub and including it alongside the GHCR images in `docker save` for the offline TSD bundle
- **`scripts/build_images.sh`**: removes the `mirror_one` scaffolding added earlier; only webserver, mysql, and cron are built/pushed
- **`CONTRIBUTING.md`**: clarifies that phpMyAdmin is not published to GHCR
- **`CHANGELOG.md`**: adds entry for 2026-03-11